### PR TITLE
Feat/add hackathon landing page

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -25,6 +25,7 @@ declare module 'vue' {
     CourseSummary: typeof import('./src/components/CourseSummary.vue')['default']
     DarkThemeToggle: typeof import('./src/components/DarkThemeToggle.vue')['default']
     Footer: typeof import('./src/components/Footer.vue')['default']
+    HackathonList: typeof import('./src/components/HackathonList.vue')['default']
     IconButton: typeof import('./src/components/IconButton.vue')['default']
     LinkIconButton: typeof import('./src/components/LinkIconButton.vue')['default']
     LocaleToggle: typeof import('./src/components/LocaleToggle.vue')['default']

--- a/components.d.ts
+++ b/components.d.ts
@@ -9,7 +9,6 @@ declare module 'vue' {
     'Carbon:binoculars': typeof import('virtual:vite-icons/carbon/binoculars')['default']
     'Carbon:bullhorn': typeof import('virtual:vite-icons/carbon/bullhorn')['default']
     'Carbon:close': typeof import('virtual:vite-icons/carbon/close')['default']
-    'Carbon:connectionTwoWay': typeof import('virtual:vite-icons/carbon/connection-two-way')['default']
     'Carbon:earth': typeof import('virtual:vite-icons/carbon/earth')['default']
     'Carbon:education': typeof import('virtual:vite-icons/carbon/education')['default']
     'Carbon:logoGithub': typeof import('virtual:vite-icons/carbon/logo-github')['default']

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,5 +1,5 @@
 landing-page:
-  banner: Check out our new hands-on course "NLP de 0 a 100"!
+  banner: Join our hackathon!
   contribute:
     button: Read more
     github: Work with us on GitHub!

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -1,5 +1,5 @@
 landing-page:
-  banner: ¡Nuevo curso práctico "NLP de 0 a 100"!
+  banner: ¡Apúntate al Hackathon de PLN en Español!
   contribute:
     button: Leer más
     github: Contribuye a nuestros proyectos en GitHub

--- a/pages/hackathon.md
+++ b/pages/hackathon.md
@@ -1,0 +1,45 @@
+---
+title: "Hackathon 2022 de PLN en Español"
+description: Contruye al lado de mentores, expertas y hackers la siguiente generación de modelos de Procesamiento del Lenguaje Natural
+---
+
+¡Únete al mayor hackathon de Procesamiento del Lenguaje Natural en español!
+
+<div class="flex justify-center">
+    <img src='https://github.com/nlp-en-es/assets/raw/main/images/hackathon_pln_es_2.png' />
+</div>
+
+La democratización del PLN en español es el objetivo principal de nuestra comunidad y una de las mejores maneras de avanzar hacia este objetivo es creando más recursos de PLN en nuestro idioma.
+
+Con este hackathon te animamos a unirte a nuestro esfuerzo. Te invitamos a entrenar y poner en producción un modelo de PLN en español.
+
+## Bases del hackathon
+
+Participar en nuestro hackathon y aplicar tus conocimientos a una buena causa es muy sencillo, ¡anímate!
+
+1. Crea una cuenta en [Hugging Face](https://huggingface.co/join) si todavía no tienes una y regístrate [aquí](./hackathon_wip) 🚀.
+2. Acepta las invitaciones que te mandemos para unirte a nuestra comunidad de Discord y a la organización [hackathon-pln-es](https://huggingface.co/hackathon-pln-es) de Hugging Face.
+3. Echa un vistazo a los diferentes canales de Discord, sobre todo a los de la sección "HACKATHON", ya que iremos anunciando talleres y material con el que preparar el hackathon y también resolveremos las dudas que te puedan surgir durante el evento.
+4. Reúne tu equipo (de 1 a 5 personas) y añádelo a [esta lista](./hackathon_wip). Si todavía no tienes equipo puedes utilizar el canal #encuentra-equipo para crear uno nuevo o unirte a uno existente.
+5. Junto con tu equipo, entrena y sube al [Hub](https://huggingface.co/models) uno o varios modelos. Desde la comunidad queremos animar a todos los equipos a entrenar modelos que sirvan para abordar alguno de los [Objetivos de Desarrollo Sostenible de la ONU](https://www.un.org/sustainabledevelopment/es/objetivos-de-desarrollo-sostenible/).
+6. Asegúrate de incluir una "Model Card" explicando, entre otras cosas, el origen de los datos utilizados y el proceso de entrenamiento del modelo. Aquí te dejamos un [ejemplo](./hackathon_wip) de referencia.
+7. Crea una demo de el/los modelo/s utilizando la tecnología que prefieras (e.g. FastAPI, Flask, Gradio, Streamlit).
+8. Por último, rellena este [formulario](./hackathon_wip) para presentar el proyecto.
+
+Un jurado formado por especialistas en PLN (por anunciar) elegirá los tres equipos ganadores. Además, se concederá una mención de honor al mejor proyecto enfocado a un Objetivo de Desarrollo Sostenible y otra al modelo con más ❤️ en el Hub de Hugging Face.
+
+¡Buena suerte!
+
+## Charlas y Talleres
+
+Durante el hackathon tendrán lugar diversas charlas y talleres impartidas por profesionales del mundo del Procesamiento del Lenguaje Natural. Iremos anunciando los eventos uno a uno así que atención a [Twitter](https://twitter.com/nlp_en_es) y [LinkedIn](https://www.linkedin.com/company/nlp-en-es)!🔥
+
+<HackathonList />
+
+## Patrocinadores
+
+<div class="auto-rows-fr grid gap-16 place-items-center lg:grid-cols-3">
+    <img class="w-screen" src='https://huggingface.co/front/assets/huggingface_logo-noborder.svg' />
+    <img class="w-screen" src='https://pbs.twimg.com/profile_images/1297483637227687936/WxoDoICa_400x400.jpg' />
+    <img class="w-screen" src='https://www.spain-ai.com/wp-content/uploads/2021/04/cropped-spain_ai-150x150.png' />    
+</div>

--- a/pages/hackathon_wip.vue
+++ b/pages/hackathon_wip.vue
@@ -1,0 +1,14 @@
+<template>
+      <Container>
+            <div
+                  class="mx-auto my-16 text-center max-w-400px grid text-2xl gap-4 place-items-center"
+            >
+                  <img
+                        src="https://nlp-en-es.github.io/assets/images/undraw_good_team_re_j1kc.svg"
+                        alt="Trabajando..."
+                  />
+                  <div class="font-bold tracking-wide text-4xl">404</div>
+                  <div class="tracking-tight">Estamos trabajando en ello</div>
+            </div>
+      </Container>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,7 @@ const showBanner = ref(true);
       @click="showBanner = false"
       class="flex flex-wrap font-semibold text-sm text-center gap-2 items-center justify-center"
     >
-      <router-link to="/nlp-de-cero-a-cien" hover="text-accent-700">{{ t('landing-page.banner') }}</router-link>
+      <router-link to="/hackathon" hover="text-accent-700">{{ t('landing-page.banner') }}</router-link>
       <carbon:close class="cursor-pointer text-lg ml-2" hover="text-accent-700" />
     </div>
   </Container>

--- a/src/components/HackathonList.vue
+++ b/src/components/HackathonList.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const routes = router.getRoutes()
+    .filter(
+        i => i.path.startsWith('/hackathon/')
+            && (i.meta as any).frontmatter.date
+    )
+    .sort((a, b) => +new Date((b.meta as any).frontmatter.date) + +new Date((a.meta as any).frontmatter.date))
+</script>
+
+<template>
+    <div class="auto-rows-fr grid gap-2 lg:grid-cols-3">
+        <BlogItem v-for="route in routes" :key="route.path" :route="route" />
+    </div>
+</template>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -14,6 +14,10 @@ const { t } = useI18n()
                 to="/nlp-de-cero-a-cien"
                 class="whitespace-nowrap hover:text-accent-500"
             >{{ "NLP de 0 a 100" }}</router-link>
+            <router-link
+                to="/hackathon"
+                class="whitespace-nowrap hover:text-accent-500"
+            >{{ "Hackathon" }}</router-link>
             <!-- <router-link
                 to="/about"
                 class="whitespace-nowrap hover:text-accent-500"


### PR DESCRIPTION
Esta PR es para añadir la MVP de la sección de la página web dedicada al hackathon.

Queda pendiente:

- Actualizar el cartel
- Añadir los enlaces que faltan en las "Bases del Hackathon"
- Añadir los logos de los nuevos patrocinadores
- Añadir las charlas y talleres según las vayamos anunciando

He añadido dummy patrocinadores y eventos para ver cómo quedaría. Podemos merge a main la MVP e ir añadiendo logos y eventos según vayamos avanzando en la organización del hackathon.